### PR TITLE
Resolve GetQuery race condition

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -161,13 +161,18 @@ impl GetQuery {
                 self.complete = have;
             }
         }
+        let have_set = self.have_set.as_mut().unwrap();
         if have {
-            self.have_set.as_mut().unwrap().insert(peer.clone());
+            have_set.insert(peer);
         } else {
-            self.have_set.as_mut().unwrap().remove(&peer);
+            have_set.remove(&peer);
         }
-        if !self.complete && have && self.block_request.is_none() {
-            self.start_request(peer);
+        if !self.complete && self.block_request.is_none() {
+            let peer = have_set.iter().next().map(|peer| peer.to_owned());
+            if let Some(peer) = peer {
+                have_set.remove(&peer);
+                self.start_request(peer);
+            }
         }
     }
 
@@ -521,6 +526,50 @@ impl QueryManager {
 mod tests {
     use super::*;
 
+    mod assert_query {
+        use super::*;
+
+        pub(super) fn is_pending(query: &mut GetQuery) {
+            assert!(matches!(query.next(), None));
+        }
+
+        pub(super) fn is_completed(query: &mut GetQuery, expected_set: FnvHashSet<PeerId>) {
+            assert!(
+                matches!(query.next(), Some(GetQueryEvent::Complete(Ok(set))) if set == expected_set)
+            );
+        }
+
+        pub(super) fn wants_have(query: &mut GetQuery, cid: &Cid) -> PeerId {
+            assert_request(query, cid, RequestType::Have)
+        }
+
+        pub(super) fn wants_block(query: &mut GetQuery, cid: &Cid) -> PeerId {
+            assert_request(query, cid, RequestType::Block)
+        }
+
+        pub(super) fn wants_block_from(query: &mut GetQuery, cid: &Cid, peer: &PeerId) {
+            assert_eq!(assert_request(query, cid, RequestType::Block), *peer);
+        }
+
+        fn assert_request(
+            query: &mut GetQuery,
+            expected_cid: &Cid,
+            expected_type: RequestType,
+        ) -> PeerId {
+            let next_ = query.next();
+            let result = match &next_ {
+                Some(GetQueryEvent::Request(peer_id, cid, type_))
+                    if cid == expected_cid && *type_ == expected_type =>
+                {
+                    Some(peer_id.to_owned())
+                }
+                _ => None,
+            };
+            assert!(result.is_some(), format!("actual: {:?}", next_));
+            result.unwrap()
+        }
+    }
+
     #[test]
     fn test_get_query_block_not_found() {
         let mut initial_set = FnvHashSet::default();
@@ -640,5 +689,61 @@ mod tests {
         assert!(
             matches!(query.next(), Some(GetQueryEvent::Complete(Ok(set))) if set == provider_set)
         );
+    }
+
+    #[test]
+    fn test_gets_block_from_spare_if_first_request_fails_before_have_is_received() {
+        let initial_set = {
+            let mut set = FnvHashSet::default();
+            set.insert(PeerId::random());
+            set.insert(PeerId::random());
+            set
+        };
+        let cid = Cid::default();
+        let mut query = GetQuery::new(cid, initial_set);
+
+        let first_peer = assert_query::wants_block(&mut query, &cid);
+        let second_peer = assert_query::wants_have(&mut query, &cid);
+
+        query.complete_request(first_peer, false);
+        assert_query::is_pending(&mut query);
+
+        query.complete_request(second_peer.to_owned(), true);
+        assert_query::wants_block_from(&mut query, &cid, &second_peer);
+
+        query.complete_request(second_peer.to_owned(), true);
+        assert_query::is_completed(&mut query, {
+            let mut set = FnvHashSet::default();
+            set.insert(second_peer);
+            set
+        });
+    }
+
+    #[test]
+    fn test_gets_block_from_spare_if_first_request_fails_after_have_is_received() {
+        let initial_set = {
+            let mut set = FnvHashSet::default();
+            set.insert(PeerId::random());
+            set.insert(PeerId::random());
+            set
+        };
+        let cid = Cid::default();
+        let mut query = GetQuery::new(cid, initial_set);
+
+        let first_peer = assert_query::wants_block(&mut query, &cid);
+        let second_peer = assert_query::wants_have(&mut query, &cid);
+
+        query.complete_request(second_peer.to_owned(), true);
+        assert_query::is_pending(&mut query);
+
+        query.complete_request(first_peer, false);
+        assert_query::wants_block_from(&mut query, &cid, &second_peer);
+
+        query.complete_request(second_peer.to_owned(), true);
+        assert_query::is_completed(&mut query, {
+            let mut set = FnvHashSet::default();
+            set.insert(second_peer);
+            set
+        });
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -171,7 +171,7 @@ impl GetQuery {
             let peer = have_set.iter().cloned().next();
             if let Some(peer) = peer {
                 have_set.remove(&peer);
-                self.start_request(peer.to_owned());
+                self.start_request(peer);
             }
         }
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -648,7 +648,7 @@ mod tests {
     }
 
     #[test]
-    fn test_gets_block_from_spare_if_first_request_fails_before_have_is_received() {
+    fn test_get_query_gets_from_spare_if_block_request_fails() {
         let cid = Cid::default();
         let mut query = GetQuery::new(cid, {
             let mut set = FnvHashSet::default();
@@ -675,7 +675,7 @@ mod tests {
     }
 
     #[test]
-    fn test_gets_block_from_spare_if_first_request_fails_after_have_is_received() {
+    fn test_get_query_gets_from_spare_if_block_request_fails_after_have_is_received() {
         let cid = Cid::default();
         let mut query = GetQuery::new(cid, {
             let mut set = FnvHashSet::default();


### PR DESCRIPTION
While integrating Bitswap in a personal project, I run into a race condition in `GetQuery` that causes requests to fail if the `HAVE` responses arrive before the inflight `WANT BLOCK` request fails.

## Observed Behavior
Given 3 peers: **A**, **B**, and **C**; **C** wants a block that both **A** and **B** have.
1. **C** sends a `WANT BLOCK` request to **A**
1. **C** sends a `WANT HAVE` request to **B** 
1. **B** sends a `HAVE` response to the **C**
1. **A** sends a `NOT HAVE` response to **C**
1. **C** should send a `WANT BLOCK` request to **B**, but it doesn't

This only happens if the `HAVE` response from **B** arrives before the `NOT HAVE` response from **A**; reversing the order of 3 and 4 will not trigger the race condition. You can get a consistent repro by artificially introducing a delay in **A**'s response.
 
## Fix
I changed the logic in `GetQuery::complete_request` to send a `WANT BLOCK` request to the first peer in the `have` set if any is present when receiving a negative response from the `WANT BLOCK` request.

I added 2 unit tests to validate the behavior:
- `test_get_query_gets_from_spare_if_block_request_fails` to confirm that the happy path worked before my change and still does
- `test_get_query_gets_from_spare_if_block_request_fails_after_have_is_received` to confirm the bug fix

I added the `assert_query` module hoping that it will make the tests easier to read, but I am willing to remove it if you think it is superfluous. I intentionally left the existing tests untouched to avoid changing both implementation and existing tests in the same commit., but I can create a separate PR for the update.

