### PR TITLE
workflow/ci: Updated ci.yml to install protoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
 
     runs-on: ${{ matrix.platform.host }}
     steps:
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v1
     - name: Checkout sources
       uses: actions/checkout@v2
 
@@ -91,6 +93,8 @@ jobs:
   lint-rust:
     runs-on: ubuntu-latest
     steps:
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v1
     - name: Checkout sources
       uses: actions/checkout@v2
 


### PR DESCRIPTION
This would update the CI to install protoc due to changes upstream requiring it to be installed on the system rather than being bundled with the crate itself. 

EDIT: It was brought up in https://github.com/ChainSafe/forest/issues/1421 regarding the CI state. 