### PR TITLE
protocol/max_buf_size: Increase max size to 2MB

### DIFF
--- a/src/compat/protocol.rs
+++ b/src/compat/protocol.rs
@@ -4,9 +4,8 @@ use futures::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use libp2p::core::{upgrade, InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use std::{io, iter};
 
-// Undocumented, but according to JS we our messages have a max size of 512*1024
-// https://github.com/ipfs/js-ipfs-bitswap/blob/d8f80408aadab94c962f6b88f343eb9f39fa0fcc/src/decision-engine/index.js#L16
-const MAX_BUF_SIZE: usize = 524_288;
+// 2MB Block Size according to the specs at https://github.com/ipfs/specs/blob/main/BITSWAP.md
+const MAX_BUF_SIZE: usize = 2_097_152;
 
 #[derive(Clone, Debug, Default)]
 pub struct CompatProtocol;


### PR DESCRIPTION
Awhile back, it was not clear on the recommended size for bitswap size but some months ago the specs at https://github.com/ipfs/specs/blob/main/BITSWAP.md#block-sizes was updated to include the max block size, which was set at 2MB, so to maintain compatibility, we will also increase that to 2MB here.

EDIT: This should probably close #20 