### PR TITLE
Make BitswapRequest and BitswapResponse public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,4 +11,5 @@ mod query;
 mod stats;
 
 pub use crate::behaviour::{Bitswap, BitswapConfig, BitswapEvent, BitswapStore, Channel};
+pub use crate::protocol::{BitswapRequest, BitswapResponse};
 pub use crate::query::QueryId;


### PR DESCRIPTION
The PR makes `BitswapRequest` and `BitswapResponse` public. 

The motivation was that I wanted to add rate limiting to a behaviour using `Bitswap`, for which I had to inspect the size of the blocks served in responses. I realized this was only possible at the moment if I read the response from the `oneshot::Sender` I see in the request first, then forward it to another channel I replace it with. To do so, however, I had to be able to declare this channel, which required the `BitswapResponse` type to be public. 

This is what I ended up with: https://github.com/consensus-shipyard/ipc-agent/pull/90

I based this fork on the commit which released `0.25`. Trying to build our code against `master` results in a conflict with `lipipld::Cid` and `cid::Cid`; some dependencies use an older version of `cid`. If this was accepted and maybe released, it would be cool if it could be done as version `0.25.1` :pray: 